### PR TITLE
issue/273 - Tasks do not show due dates

### DIFF
--- a/doto-frontend/src/components/pages/Calendar/CalendarComponent.js
+++ b/doto-frontend/src/components/pages/Calendar/CalendarComponent.js
@@ -72,6 +72,10 @@ const useStyles = makeStyles(theme => ({
         boxShadow: theme.shadows[5],
         padding: theme.spacing(2, 4, 3),
     },
+    dueContainer: {
+        margin: "0 auto",
+        color: "red",
+    },
 }));
 
 export function Content({
@@ -111,6 +115,11 @@ export function Content({
 
     return (
         <AppointmentTooltip.Content {...restProps} appointmentData={appointmentData}>
+            <Grid container alignItems="center">
+                <div className={classes.dueContainer}>
+                    <div>Due: {new Date(appointmentData.dueDate).toLocaleString()}</div>
+                </div>
+            </Grid>
             <Grid container alignItems="center">
                 <div className="footer-container">
                     <div>


### PR DESCRIPTION
- [ ] The pull request is complete according to the following criteria:
  - [x] Acceptance criteria have been met
  - [ ] The documentation is kept up-to-date
  - [ ] Comprehensive tests (if applicable) have been generated and all pass.
  - [x] The pull request describes the changes that have been made, and enough information is present in the description for any developer to understand what has changed
  - [x] Commits have been squashed (or will be on merge).
  - [x] The branch name is descriptive and follows the pull request title format : {issue/bug...}/(Issue Number) - Name of issue. E.g bug/30-Fix-Project
  - [x] The pull request title is of the following format : {issue/bug...}/(Issue Number) - Name of issue. E.g bug/30-Fix-Project
  - [x] The description uses [github syntax](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) to link to the issue. E,g Resolves se701g2/Doto#{Number}
  - [x] At least two reviewers assigned. One of which must be the assigner of the issue.
  - [ ] If there are merge conflicts, run git rebase as opposed to git merge with master.

---

Resolves issue #273 (Small typo on branch name).

Updates the CalenderComponent's modal to also display the Due date for a given task, as it's information is not used inside of Doto, an automatic scheduling app.

Current Behaviour:
![image](https://user-images.githubusercontent.com/48403060/80273218-759cbc80-8724-11ea-91d4-ed860b373377.png)

Proposed Behaviour:
![image](https://user-images.githubusercontent.com/48403060/80273214-6f0e4500-8724-11ea-8113-8165f706400c.png)

Extra:

There seems to be another bug where:
1. Adding a fresh task will populate the `dueDate` field with a `Date` object.
2. After refreshing the page, this `dueDate` is then updated to a `String`.

This however, does not affect this PR as functionality is not broken - but worth investigating.